### PR TITLE
solucionados errores del frontend en las conversaciones

### DIFF
--- a/FrontEnd/chatify-front/src/components/NavMenu.tsx
+++ b/FrontEnd/chatify-front/src/components/NavMenu.tsx
@@ -79,7 +79,9 @@ const NavMenu: React.FC<NavMenuProps> = ({
                         setMenuAnchorEl(e.currentTarget);
                         setMenuTabId(tab.id);
                       }}
-                      sx={{ color: menuTabId === tab.id ? "white" : "grey" }}
+                      sx={{ color: menuTabId === tab.id ? "white" : "grey" ,
+                            '&:focus': { outline: 'none' },
+                      }}
                       >
                     <MoreVertIcon fontSize="small" />
                   </IconButton>
@@ -137,7 +139,7 @@ const NavMenu: React.FC<NavMenuProps> = ({
         {openRenameForm && (
           <CustomDialog
             open={openRenameForm}
-            onClose={() => setOpenRenameForm(false)}
+            onClose={() => {setOpenRenameForm(false); setMenuTabId(null);}}
             onConfirm={handleDialogAccept}
           >
             <Form

--- a/FrontEnd/chatify-front/src/components/TopBar.tsx
+++ b/FrontEnd/chatify-front/src/components/TopBar.tsx
@@ -12,7 +12,7 @@ const TopBar: React.FC = () => {
   };
 
   return (
-    <AppBar position="static" sx={{ backgroundColor: '#121212', color: '#fff' }}>
+    <AppBar position="static"  sx={{ backgroundColor: '#121212', color: '#fff', zIndex: 10 }}>
       <Toolbar>
 
         <Box 

--- a/FrontEnd/chatify-front/src/layouts/MainLayout.tsx
+++ b/FrontEnd/chatify-front/src/layouts/MainLayout.tsx
@@ -109,11 +109,10 @@ const MainLayout = () => {
       return <div></div>;
     }
 
-    const chat = chats.find((chat) => chat.id === selectedTab);
+    const chat = chats.find((chat) => String(chat.id) === String(selectedTab));
     if (chat) {
       return <Chat chatId={chat.id} />;
     }
-
     return <div>Tab no encontrada</div>;
   };
 


### PR DESCRIPTION
las tabs de las conversaciones ahora siempre se reidirigen, topbar sombrea a todo, el menu despegables de las conversaciones al ser seleccionado no aparece un circulo blanco rodeandolo y cuando se cancela cambiar nombre se cambia a gris los tres puntos